### PR TITLE
Feature Request: Add the application name as a tag to "Submit a ticket" button click

### DIFF
--- a/start_jupyter
+++ b/start_jupyter
@@ -396,8 +396,9 @@ require(["jquery", "base/js/namespace", "base/js/dialog"],
 
         var term = document.getElementById("login_widget");
         var url = `https://${host}/tools/anonymous/stop?sess=${session}`;
+        var appname = '""" + app_name + """';
 
-        term.innerHTML = `<button class="btn btn-sm navbar-btn" title="Report a problem" onclick="window.open('https://${lhost}.org/feedback/report_problems?group=app-${app_namename}')">Submit a ticket</button>&nbsp;&nbsp;<button class="btn btn-sm navbar-btn" title="Terminate this notebook or tool and any others in the session" onclick="window.location.href='${url}'">Terminate Session</button>`;
+        term.innerHTML = `<button class="btn btn-sm navbar-btn" title="Report a problem" onclick="window.open('https://${lhost}.org/feedback/report_problems?group=app-${appname}')">Submit a ticket</button>&nbsp;&nbsp;<button class="btn btn-sm navbar-btn" title="Terminate this notebook or tool and any others in the session" onclick="window.location.href='${url}'">Terminate Session</button>`;
 
         try {
             var quit = document.getElementById("shutdown");


### PR DESCRIPTION
**Additions:**
- Created a function named "parse_app_name" that will attempt to retrieve the application name from environment variables TOOLDIR or SUBMIT_APPLICATION_REVISION. If the name cannot be found, then get the application title from $SESSIONDIR/resources
- Added a Python variable for app_name
- Added to the header_template, the Javascript variable appname using the Python value
- Added ?group=app-${appname} to the HREF for the "Submit a ticket" button

**Purpose:**
The reason behind this change is too add a tag to ticket requests letting developers know what tool the ticket is in reference too. Sometimes ticket submitters omit this information